### PR TITLE
Add a Fault Sensor and Compound sensor types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samsynk"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Sam Howson <sam@samhowson.co.uk>"]
 

--- a/samsynk-exporter/src/main.rs
+++ b/samsynk-exporter/src/main.rs
@@ -86,6 +86,7 @@ async fn data_collector() {
                 SensorTypes::Basic(s) => s.read(ctx).await.unwrap(),
                 SensorTypes::Temperature(s) => s.read(ctx).await.unwrap(),
                 SensorTypes::Serial(_) => (ctx, String::new()),
+                SensorTypes::Fault(_) => (ctx, String::new()),
             }
         }
     }

--- a/src/sensor_definitions.rs
+++ b/src/sensor_definitions.rs
@@ -8,8 +8,8 @@ lazy_static! {
         registers: [3, 4, 5, 6, 7],
     };
 
-    pub static ref FAULTS: FaultSensor<'static> = FaultSensor {
-        registers: &[103, 104, 105, 106],
+    pub static ref FAULTS: FaultSensor = FaultSensor {
+        registers: [103, 104, 105, 106],
     };
 
     pub static ref TEMP_SENSORS: [TemperatureSensor<'static>; 4] = [


### PR DESCRIPTION
This change adds two new sensor types- Fault and Compound. Fault sensors should only be used in a single case- reporting faults. Compound sensors are made from multiple registers.